### PR TITLE
Update sc-google-code-style-check.yml

### DIFF
--- a/.github/workflows/sc-google-code-style-check.yml
+++ b/.github/workflows/sc-google-code-style-check.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v2 # v2 minimum required
       - uses: axel-op/googlejavaformat-action@v2.0.0
         with:
-          args: "--replace"
+          args: "--dry-run --skip-sorting-imports --set-exit-if-changed"


### PR DESCRIPTION
Change the Google Code style settings to use the dry-run functionality (not commit automatically) and to exit as code 1 (failure) if changes required.